### PR TITLE
fix: evaluateFlags context

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,11 @@ const ExamplePage: NextPage<Data> = ({ isEnabled, variant }) => (
 export const getStaticProps: GetStaticProps<Data> = async (_ctx) => {
   /* Using server-side SDK: */
   const definitions = await getDefinitions();
-  const { toggles } = evaluateFlags(definitions);
+  const context = {} // optional, see https://docs.getunleash.io/reference/unleash-context 
+  const { toggles } = evaluateFlags(definitions, context);
 
   /* Or with the proxy/front-end API */
-  // const { toggles } = await getFrontendFlags();
+  // const { toggles } = await getFrontendFlags({ context });
 
   const flags = flagsClient(toggles);
 
@@ -184,7 +185,7 @@ export const getServerSideProps: GetServerSideProps<Data> = async (ctx) => {
     // userId: "123" // etc
   };
 
-  const { toggles } = await getFrontendFlags(); // Use Proxy/Frontend API
+  const { toggles } = await getFrontendFlags({ context }); // Use Proxy/Frontend API
   const flags = flagsClient(toggles);
 
   return {

--- a/lib/src/evaluateFlags.ts
+++ b/lib/src/evaluateFlags.ts
@@ -8,18 +8,27 @@ import { ToggleEngine } from "./core/engine";
  */
 export const evaluateFlags = (
   definitions: ClientFeaturesResponse,
-  context: Context
+  context: Context = {}
 ) => {
   const engine = new ToggleEngine(definitions);
   const toggles: IToggle[] = [];
+  const defaultContext: Context = {
+    currentTime: new Date(),
+    appName:
+      process.env.UNLEASH_APP_NAME || process.env.NEXT_PUBLIC_UNLEASH_APP_NAME,
+  };
+  const contextWithDefaults = {
+    ...defaultContext,
+    ...context,
+  };
 
   definitions?.features?.forEach((feature) => {
-    const enabled = engine.isEnabled(feature.name, context);
+    const enabled = engine.isEnabled(feature.name, contextWithDefaults);
     if (!enabled) {
       return;
     }
 
-    const variant = engine.getVariant(feature.name, context);
+    const variant = engine.getVariant(feature.name, contextWithDefaults);
     if (variant.payload === undefined) {
       delete variant.payload; // cleanup before serialization
     }


### PR DESCRIPTION
Set `context` parameter as optional in `evaluateFlags`, but add defaults and update documentation.

Closes #22 
