### PR TITLE
fix: URL trailing slash

### DIFF
--- a/lib/src/flagsClient.test.ts
+++ b/lib/src/flagsClient.test.ts
@@ -1,6 +1,8 @@
 import { flagsClient } from "./flagsClient";
 
 describe("flagsClient", () => {
+  global.fetch = vi.fn();
+
   it("should return methods", () => {
     const client = flagsClient();
     expect(client).toHaveProperty("isEnabled");

--- a/lib/src/getDefinitions.test.ts
+++ b/lib/src/getDefinitions.test.ts
@@ -1,4 +1,4 @@
-import { getDefinitions } from "./getDefinitions";
+import { getDefinitions, getDefaultConfig } from "./getDefinitions";
 
 const mockFetch = vi.fn();
 const mockConsole = {
@@ -89,6 +89,7 @@ describe("getDefinitions", () => {
       expect.anything()
     );
   });
+
   it("should allow for overriding the default config", () => {
     const url = "http://example.com/api/client/features";
     const token = "secure-token";
@@ -111,5 +112,37 @@ describe("getDefinitions", () => {
 
     expect(mockConsole.warn).not.toHaveBeenCalled();
     expect(mockConsole.error).not.toHaveBeenCalled();
+  });
+
+  it('should not modify "url" in config', () => {
+    const url = "http://example.com/api/";
+    getDefinitions({
+      url,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(url, expect.anything());
+  });
+});
+
+describe("getDefaultConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("should support UNLEASH_SERVER_API_URL with trailing slash", () => {
+    vi.stubEnv("UNLEASH_SERVER_API_URL", "http://example.com/api/");
+
+    expect(getDefaultConfig()).toHaveProperty(
+      "url",
+      "http://example.com/api/client/features"
+    );
+  });
+  it("should support NEXT_PUBLIC_UNLEASH_SERVER_API_URL with trailing slash", () => {
+    vi.stubEnv("NEXT_PUBLIC_UNLEASH_SERVER_API_URL", "http://example.org/api/");
+
+    expect(getDefaultConfig()).toHaveProperty(
+      "url",
+      "http://example.org/api/client/features"
+    );
   });
 });

--- a/lib/src/getDefinitions.ts
+++ b/lib/src/getDefinitions.ts
@@ -1,12 +1,14 @@
 import type { ClientFeaturesResponse } from "unleash-client";
+import { removeTrailingSlash } from "./utils";
 
 const defaultUrl = "http://localhost:4242/api/client/features";
 const defaultToken = "default:development.unleash-insecure-api-token";
 
 export const getDefaultConfig = (defaultAppName = "nextjs") => {
-  const baseUrl =
+  const baseUrl = removeTrailingSlash(
     process.env.UNLEASH_SERVER_API_URL ||
-    process.env.NEXT_PUBLIC_UNLEASH_SERVER_API_URL;
+      process.env.NEXT_PUBLIC_UNLEASH_SERVER_API_URL
+  );
 
   return {
     appName:
@@ -21,6 +23,9 @@ export const getDefaultConfig = (defaultAppName = "nextjs") => {
 
 /**
  * Fetch Server-side feature flags definitions from Unleash API
+ *
+ * If you provide `url` in the config parameter, it should be a full endpoint path:
+ * @example getDefinitions({ url: `http://localhost:4242/api/client/features` })
  */
 export const getDefinitions = async (
   config?: Partial<ReturnType<typeof getDefaultConfig>>

--- a/lib/src/utils.test.ts
+++ b/lib/src/utils.test.ts
@@ -1,4 +1,8 @@
-import { getDefaultClientConfig, safeCompare } from "./utils";
+import {
+  getDefaultClientConfig,
+  removeTrailingSlash,
+  safeCompare,
+} from "./utils";
 
 describe("getDefaultClientConfig", () => {
   afterEach(() => {
@@ -142,5 +146,27 @@ describe("safeCompare", () => {
     ["pre", "prefix"],
   ])(`should return false for %s and %s`, (a, b) => {
     expect(safeCompare(a, b)).toBe(false);
+  });
+});
+
+describe("removeTrailSlash", () => {
+  it("should remove trailing slash", () => {
+    expect(removeTrailingSlash("/foo/bar/")).toBe("/foo/bar");
+  });
+
+  it("should not modify strings without trailing slash", () => {
+    expect(removeTrailingSlash("/foo/bar")).toBe("/foo/bar");
+  });
+
+  it("should remove only one trailing slash", () => {
+    expect(removeTrailingSlash("/foo/bar//")).toBe("/foo/bar/");
+  });
+
+  it("should work with empty string", () => {
+    expect(removeTrailingSlash("")).toBe("");
+  });
+
+  it("should work with undefined", () => {
+    expect(removeTrailingSlash(undefined)).toBe(undefined);
   });
 });

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -59,3 +59,6 @@ export const getDefaultClientConfig = () => {
       "default:development.unleash-insecure-frontend-api-token",
   };
 };
+
+export const removeTrailingSlash = (url?: string) =>
+  url && url.replace(/\/$/, "");


### PR DESCRIPTION
Closes #20 

Allow for trailing slash in `UNLEASH_SERVER_API_URL` and `NEXT_PUBLIC_UNLEASH_SERVER_API_URL`.
