### PR TITLE
InstanceId can be set; Token is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ If using **server-side** (SSR, SSG, API), using `getDefinitions()` and `evaluate
 
 - `UNLEASH_SERVER_API_URL` of you instance. URL should end with `/api`
 - `UNLEASH_SERVER_API_TOKEN` [server-side API client token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#client-tokens)
+- `UNLEASH_SERVER_INSTANCE_ID` in some cases (for example [GitLab Feature Flags](https://docs.gitlab.com/ee/operations/feature_flags.html)) you might want to use instanceId
 
 #### Detailed explanation
 
 | Prefixable     | Variable                     | Default                                                   |
-| -------------- | ---------------------------- | --------------------------------------------------------- |
+| -------------- |------------------------------|-----------------------------------------------------------|
 | `NEXT_PUBLIC_` | `UNLEASH_SERVER_API_URL`     | `http://localhost:4242/api`                               |
 | `NEXT_PUBLIC_` | `UNLEASH_FRONTEND_API_URL`   | `<(NEXT_PUBLIC_)UNLEASH_SERVER_API_URL>/frontend`         |
-| **No**         | `UNLEASH_SERVER_API_TOKEN`   | `default:development.unleash-insecure-api-token`          |
+| **No**         | `UNLEASH_SERVER_API_TOKEN`   | **No**                                                    |
+| **No**         | `UNLEASH_SERVER_INSTANCE_ID` | **No**                                                    |
 | `NEXT_PUBLIC_` | `UNLEASH_FRONTEND_API_TOKEN` | `default:development.unleash-insecure-frontend-api-token` |
 | `NEXT_PUBLIC_` | `UNLEASH_APP_NAME`           | `nextjs`                                                  |
 

--- a/lib/src/cli/helpers.test.ts
+++ b/lib/src/cli/helpers.test.ts
@@ -31,7 +31,6 @@ describe("fetchDefinitions", () => {
     expect(getDefinitions).toHaveBeenCalledOnce();
     expect(getDefinitions).toHaveBeenLastCalledWith({
       appName: "cli",
-      token: "default:development.unleash-insecure-api-token",
       url: "http://localhost:4242/api/client/features",
     });
     expect(result).toEqual({
@@ -45,7 +44,6 @@ describe("fetchDefinitions", () => {
     await fetchDefinitions();
     expect(getDefinitions).toHaveBeenLastCalledWith({
       appName: "cli",
-      token: "default:development.unleash-insecure-api-token",
       url: "http://example.com/api/client/features",
     });
   });
@@ -58,6 +56,17 @@ describe("fetchDefinitions", () => {
     expect(getDefinitions).toHaveBeenLastCalledWith({
       appName: "cli",
       token: "project:env-name.token",
+      url: "http://localhost:4242/api/client/features",
+    });
+  });
+
+  it("is using UNLEASH_SERVER_INSTANCE_ID", async () => {
+    vi.stubEnv("UNLEASH_SERVER_INSTANCE_ID", "project:env-name.instance-id");
+
+    await fetchDefinitions();
+    expect(getDefinitions).toHaveBeenLastCalledWith({
+      appName: "cli",
+      instanceId: "project:env-name.instance-id",
       url: "http://localhost:4242/api/client/features",
     });
   });

--- a/lib/src/cli/helpers.ts
+++ b/lib/src/cli/helpers.ts
@@ -31,13 +31,13 @@ export const step = (message: string, ...params: string[]) => {
 export const error = (message: string) => [c4, message, r].join("");
 
 export const fetchDefinitions = async () => {
-  const { url, token, appName } = getDefaultConfig("cli");
+  const { url, token, instanceId, appName } = getDefaultConfig("cli");
 
   step("- Fetching feature toggle definitions");
   step("API:", url);
-  step("environment:", token.split(".")[0].split(":").slice(-1)[0]);
+  token && step("environment:", token.split(".")[0].split(":").slice(-1)[0]);
 
-  const definitions = await getDefinitions({ url, token, appName });
+  const definitions = await getDefinitions({ url, token, instanceId, appName });
 
   if (!definitions || !definitions.features) {
     throw new Error(

--- a/lib/src/getDefinitions.test.ts
+++ b/lib/src/getDefinitions.test.ts
@@ -32,7 +32,6 @@ describe("getDefinitions", () => {
       "http://localhost:4242/api/client/features",
       {
         headers: {
-          Authorization: "default:development.unleash-insecure-api-token",
           "Content-Type": "application/json",
           "UNLEASH-APPNAME": "nextjs",
           "User-Agent": "nextjs",
@@ -47,11 +46,11 @@ describe("getDefinitions", () => {
     expect(mockConsole.warn).toHaveBeenCalled();
   });
 
-  it("should show an error when using default token", () => {
+  it("should show an warning when neither token nor instanceId is used", () => {
     getDefinitions();
 
-    expect(mockConsole.error).toHaveBeenCalledWith(
-      expect.stringContaining("Using fallback default token.")
+    expect(mockConsole.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Neither token nor instanceId is used.")
     );
   });
 


### PR DESCRIPTION
## About the changes
In order to make it work with GitLab FF which uses only name, url and instance_id as auth I've made token optional and possibility to add instance_id through environment variables.

<!-- Does it close an issue? Multiple? -->
Closes #21 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
- lib/src/cli/helpers.ts
- lib/src/getDefinitions.test.ts


## Discussion points
I've tested this solution in my use-case with GitLab connection and everything works fine. I've also modified some tests. As long as I don't use Unleash server I would apriciate double-check by someone who does.

If there are flaws, let me know and I'll try to fix it.
