### PR TITLE
Possibility to add instance_id and omit token

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unleash/nextjs",
-  "version": "0.1.1",
+  "version": "0.1.3-alpha.0",
   "description": "Unleash SDK for Next.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/lib/src/cli/helpers.test.ts
+++ b/lib/src/cli/helpers.test.ts
@@ -62,6 +62,29 @@ describe("fetchDefinitions", () => {
     });
   });
 
+  it("is using UNLEASH_SERVER_INSTANCE_ID", async () => {
+    vi.stubEnv("UNLEASH_SERVER_INSTANCE_ID", "SomeInstance_ID");
+
+    await fetchDefinitions();
+    expect(getDefinitions).toHaveBeenLastCalledWith({
+      appName: "cli",
+      instanceId: "SomeInstance_ID",
+      token: "default:development.unleash-insecure-api-token",
+      url: "http://localhost:4242/api/client/features",
+    });
+  });
+
+  it("can omit UNLEASH_SERVER_API_TOKEN", async () => {
+    vi.stubEnv("UNLEASH_SERVER_API_TOKEN", "false");
+
+    await fetchDefinitions();
+    expect(getDefinitions).toHaveBeenLastCalledWith({
+      appName: "cli",
+      token: false,
+      url: "http://localhost:4242/api/client/features",
+    });
+  });
+
   it("throws an error when the response doesn't have feature toggles", async () => {
     getDefinitions.mockImplementation(
       () =>

--- a/lib/src/cli/helpers.ts
+++ b/lib/src/cli/helpers.ts
@@ -31,13 +31,20 @@ export const step = (message: string, ...params: string[]) => {
 export const error = (message: string) => [c4, message, r].join("");
 
 export const fetchDefinitions = async () => {
-  const { url, token, appName } = getDefaultConfig("cli");
+  const { url, token, instanceId, appName } = getDefaultConfig("cli");
 
   step("- Fetching feature toggle definitions");
   step("API:", url);
-  step("environment:", token.split(".")[0].split(":").slice(-1)[0]);
 
-  const definitions = await getDefinitions({ url, token, appName });
+  if (token) {
+    step("environment:", token.split(".")[0].split(":").slice(-1)[0]);
+  }
+
+  if (instanceId) {
+    step("instanceId:", instanceId.slice(0,2) + '*'.repeat(instanceId.length - 4) + instanceId.slice(-2));
+  }
+
+  const definitions = await getDefinitions({ url, token, instanceId, appName });
 
   if (!definitions || !definitions.features) {
     throw new Error(

--- a/lib/src/cli/helpers.ts
+++ b/lib/src/cli/helpers.ts
@@ -40,7 +40,7 @@ export const fetchDefinitions = async () => {
     step("environment:", token.split(".")[0].split(":").slice(-1)[0]);
   }
 
-  if (instanceId) {
+  if (instanceId && instanceId.length > 6) {
     step("instanceId:", instanceId.slice(0,2) + '*'.repeat(instanceId.length - 4) + instanceId.slice(-2));
   }
 

--- a/lib/src/getDefinitions.ts
+++ b/lib/src/getDefinitions.ts
@@ -8,13 +8,17 @@ export const getDefaultConfig = (defaultAppName = "nextjs") => {
     process.env.UNLEASH_SERVER_API_URL ||
     process.env.NEXT_PUBLIC_UNLEASH_SERVER_API_URL;
 
+  const token = process.env.UNLEASH_SERVER_API_TOKEN;
+  const resolvedToken: string | false = (token === 'false' ? false : token || defaultToken);
+
   return {
     appName:
       process.env.UNLEASH_APP_NAME ||
       process.env.NEXT_PUBLIC_UNLEASH_APP_NAME ||
       defaultAppName,
     url: baseUrl ? `${baseUrl}/client/features` : defaultUrl,
-    token: process.env.UNLEASH_SERVER_API_TOKEN || defaultToken,
+    token: resolvedToken,
+    instanceId: process.env.UNLEASH_SERVER_INSTANCE_ID,
     fetchOptions: {} as RequestInit,
   };
 };
@@ -25,7 +29,13 @@ export const getDefaultConfig = (defaultAppName = "nextjs") => {
 export const getDefinitions = async (
   config?: Partial<ReturnType<typeof getDefaultConfig>>
 ) => {
-  const { appName, url, token, fetchOptions } = {
+  const {
+    appName,
+    url,
+    token,
+    instanceId,
+    fetchOptions: { headers = {}, ...options },
+  } = {
     ...getDefaultConfig(),
     ...(config || {}),
   };
@@ -42,14 +52,23 @@ export const getDefinitions = async (
     );
   }
 
-  const response = await fetch(url, {
-    ...fetchOptions,
+  const fetchUrl = new URL(url);
+
+  if (token) {
+    Object.assign(headers, { Authorization: token });
+  }
+
+  if (instanceId) {
+    fetchUrl.searchParams.append('instance_id', instanceId)
+  }
+
+  const response = await fetch(fetchUrl.toString(), {
+    ...options,
     headers: {
       "Content-Type": "application/json",
       "UNLEASH-APPNAME": appName,
       "User-Agent": appName,
-      Authorization: token,
-      ...(fetchOptions.headers || {}),
+      ...headers,
     },
   });
 


### PR DESCRIPTION
Based on [PR and its review](https://github.com/Unleash/unleash-client-nextjs/pull/26) I've created new PR with different approach. It still makes it work with GitLab FF but instead of removing `defaultToken` it adds possibility to set token to `false` and omit it and also adds possibility to set instance_id. So this solution does not edit any of existing tests.

- InstanceID works like a token so I find it somehow sensitive. Because of that it masks output in debug and dumps only first and last 2 characters.
- Token can be omitted by setting up env value to 'false'

<!-- Does it close an issue? Multiple? -->
Closes https://github.com/Unleash/unleash-client-nextjs/issues/21