### PR TITLE
fix: breaking yarn change for pnpm coop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: 🚀 Release
 
+env:
+  # https://github.com/yarnpkg/yarn/issues/9015 remove after we switch to one package manager (yarn)
+  SKIP_YARN_COREPACK_CHECK: 1
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

yarn 1.21.21 introduces breaking change with pnpm + yarn used together:
https://github.com/yarnpkg/yarn/issues/9015 and https://github.com/actions/setup-node/issues/899. Before we switch to yarn and remove pnpm I added a workaround so that we can release new versions.

The env var should disabled a breaking change that was added after 1.21.19 (last version that was working for us): 
https://github.com/yarnpkg/yarn/blob/1.22-stable/src/cli/index.js#L292C21-L292C33

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
