### PR TITLE
Update SSR instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Both `getDefinitions()` and `getFrontendFlags()` can take arguments overriding U
 import {
   flagsClient,
   evaluateFlags,
-  getFrontendFlags,
+  getDefinitions,
   type IVariant,
 } from "@unleash/nextjs";
 import type { GetServerSideProps, NextPage } from "next";
@@ -241,12 +241,17 @@ export const getServerSideProps: GetServerSideProps<Data> = async (ctx) => {
     // userId: "123" // etc
   };
 
-  const { toggles } = await getFrontendFlags({ context }); // Use Proxy/Frontend API
-  const flags = flagsClient(toggles);
+  const definitions = await getDefinitions(); // Uses UNLEASH_SERVER_API_URL
+  const { toggles } = evaluateFlags(definitions, context);
+
+  const flags = flagsClient(toggles); // instantiates a static (non-syncing) unleash-proxy-client
 
   return {
     props: {
       isEnabled: flags.isEnabled("nextjs-example"),
+      // Or you can skip the flagsClient and access the toggles directly, but this will skip impression logging
+      // and other client logic from unleash-proxy-client
+      isEnabled: toggles.find((t) => t.name === 'FEATURE_NAME').enabled
     },
   };
 };

--- a/README.md
+++ b/README.md
@@ -248,10 +248,7 @@ export const getServerSideProps: GetServerSideProps<Data> = async (ctx) => {
 
   return {
     props: {
-      isEnabled: flags.isEnabled("nextjs-example"),
-      // Or you can skip the flagsClient and access the toggles directly, but this will skip impression logging
-      // and other client logic from unleash-proxy-client
-      isEnabled: toggles.find((t) => t.name === 'FEATURE_NAME').enabled
+      isEnabled: flags.isEnabled("nextjs-example")
     },
   };
 };


### PR DESCRIPTION
Use server-side SDK instead of client-side

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
My understanding is that server-side code such as getServerSideProps should be using Unleash's server-side SDK, not the client-side SDK implemented in unleash-proxy-client... (right?)


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
In reality, I think that this scenario should be leveraging the `unleash-client` [Node SDK](https://docs.getunleash.io/reference/sdks/node) package, rather than any of the client-side types (i.e. `IToggle`) or functionality provided by the `unleash-proxy-client` frontend package.  Which we could provide an example for here, but ideally this library should wrap that in something that defaults to using the same environment variables to configure a client, and maintain a singleton instance for you, etc.

Using the Node client on the server-side would allow the app to have a singleton client instance that syncs itself with the Unleash server periodically, as recommended by the Unleash docs, and the user would only need to import that client and call `isEnabled` as needed, passing in a relevant context.  I guess that's all being discussed in https://github.com/Unleash/unleash-client-nextjs/issues/45.  For now, this PR at least demonstrates how to utilize the server-side SDK for server-side code.
