### PR TITLE
docs: remove evaluateFlags await

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const getFlag = async () => {
     },
   });
 
-  const { toggles } = await evaluateFlags(definitions, {
+  const { toggles } = evaluateFlags(definitions, {
     sessionId,
   });
   const flags = flagsClient(toggles);

--- a/example/src/app/api-route/route.ts
+++ b/example/src/app/api-route/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const definitions = await getDefinitions();
-    const { toggles } = await evaluateFlags(definitions, {
+    const { toggles } = evaluateFlags(definitions, {
       sessionId,
     });
     const flags = flagsClient(toggles);

--- a/example/src/app/server-page-advanced/page.tsx
+++ b/example/src/app/server-page-advanced/page.tsx
@@ -27,7 +27,7 @@ const getData = async () => {
       },
     });
 
-    const { toggles } = await evaluateFlags(definitions, {
+    const { toggles } = evaluateFlags(definitions, {
       sessionId, // it is important to provide sticky field for a consistent user experience (https://docs.getunleash.io/reference/stickiness#calculation)
     });
     const flags = flagsClient(toggles);

--- a/example/src/middleware.ts
+++ b/example/src/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(req: NextRequest) {
         const definitions = await fetch(definitionsUrl).then((res) => res.json());
       
         // Evaluate based on provided context
-        const evaluated = await evaluateFlags(definitions, context);
+        const evaluated = evaluateFlags(definitions, context);
         const variant = flagsClient(evaluated.toggles).getVariant("nextjs-example")
           ?.payload?.value;
       

--- a/example/src/pages/api/hello.ts
+++ b/example/src/pages/api/hello.ts
@@ -29,7 +29,7 @@ export default async function handler(req: NextRequest) {
     };
 
     const definitions = await getDefinitions();
-    const { toggles } = await evaluateFlags(definitions, context);
+    const { toggles } = evaluateFlags(definitions, context);
 
     return new Response(JSON.stringify({ toggles }), {
       status: 200,


### PR DESCRIPTION
evaluateFlags contains no asynchronous actions and is not an asynchronous function. Removing the awaits from the examples to remove the false impression that this operation is asynchronous. 

Fixes #84 