### PR TITLE
fix: evaluateFlags error if definitions are not provided

### DIFF
--- a/lib/src/evaluateFlags.test.ts
+++ b/lib/src/evaluateFlags.test.ts
@@ -1,0 +1,43 @@
+import { evaluateFlags } from "./evaluateFlags";
+import type { ClientFeaturesResponse } from "unleash-client";
+
+describe("evaluateFlags", () => {
+  it("should return toggles when engine initializes successfully", () => {
+    const definitions: ClientFeaturesResponse = {
+      version: 1,
+      features: [
+        { name: "featureA", enabled: true },
+        { name: "featureB", enabled: false },
+      ],
+    };
+
+    const result = evaluateFlags(definitions, {});
+
+    expect(result).toEqual({
+      toggles: [
+        {
+          name: "featureA",
+          enabled: true,
+          impressionData: false,
+          variant: {
+            enabled: false,
+            feature_enabled: true,
+            name: "disabled",
+          },
+        },
+      ],
+    });
+  });
+
+  it("should return empty toggles when engine initialization fails", () => {
+    const definitions = {
+      message: "Invalid definitions",
+    };
+
+    const result = evaluateFlags(definitions as any, {});
+
+    expect(result).toEqual({
+      toggles: [],
+    });
+  });
+});

--- a/lib/src/evaluateFlags.ts
+++ b/lib/src/evaluateFlags.ts
@@ -12,7 +12,17 @@ export const evaluateFlags = (
 ): {
   toggles: IToggle[];
 } => {
-  const engine = new ToggleEngine(definitions);
+  let engine: ToggleEngine;
+  try {
+    engine = new ToggleEngine(definitions);
+  } catch (error) {
+    console.error(
+      "Unleash: Failed to evaluate flags from provided definitions",
+      error
+    );
+    return { toggles: [] };
+  }
+
   const defaultContext: Context = {
     currentTime: new Date(),
     appName:


### PR DESCRIPTION
## About the changes
If there was an error in feature flags passed, engine will throw an error. This prevents error propagation, defaulting flags to all-off.