### PR TITLE
feat: flush metrics from client

### DIFF
--- a/lib/src/flagsClient.ts
+++ b/lib/src/flagsClient.ts
@@ -11,9 +11,9 @@ export const flagsClient = (toggles = [] as IToggle[]) => {
     fetch: () => null,
     createAbortController: () => null,
     refreshInterval: 0,
+    metricsInterval: 0,
     disableRefresh: true,
     bootstrapOverride: true,
-    disableMetrics: true,
     storageProvider: {
       get: async (_name: string) => {},
       save: async (_name: string, _value: string) => {},
@@ -23,5 +23,6 @@ export const flagsClient = (toggles = [] as IToggle[]) => {
   return {
     isEnabled: (name: string) => client.isEnabled(name),
     getVariant: (name: string) => client.getVariant(name),
+    sendMetrics: () => client.sendMetrics(),
   };
 };


### PR DESCRIPTION
## About the changes

Experimental metrics support for server-side (https://github.com/Unleash/unleash-client-nextjs/issues/50)

`flagsClient.sendMetrics()`