### PR TITLE
feat: expose all flagsClient functions

### DIFF
--- a/lib/src/flagsClient.ts
+++ b/lib/src/flagsClient.ts
@@ -43,9 +43,5 @@ export const flagsClient = (
     },
   });
 
-  return {
-    isEnabled: (name: string) => client.isEnabled(name),
-    getVariant: (name: string) => client.getVariant(name),
-    sendMetrics: () => client.sendMetrics(),
-  };
+  return client;
 };


### PR DESCRIPTION
I mainly needed `getAllToggles()` from the flagsClient(), but there's much more, why not expose the full client instead of a selection of functions?