### PR TITLE
feat: add sdk uniqueness headers

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -54,7 +54,7 @@
     "murmurhash3js": "3.0.1",
     "semver": "7.6.3",
     "unleash-client": "6.1.1",
-    "unleash-proxy-client": "3.6.1"
+    "unleash-proxy-client": "^3.7.1"
   },
   "peerDependencies": {
     "next": ">=12",

--- a/lib/package.json
+++ b/lib/package.json
@@ -53,7 +53,7 @@
     "commander": "12.1.0",
     "murmurhash3js": "3.0.1",
     "semver": "7.6.3",
-    "unleash-client": "6.1.1",
+    "unleash-client": "^6.4.0",
     "unleash-proxy-client": "^3.7.1"
   },
   "peerDependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -54,7 +54,7 @@
     "murmurhash3js": "3.0.1",
     "semver": "7.6.3",
     "unleash-client": "^6.4.1",
-    "unleash-proxy-client": "^3.7.1"
+    "unleash-proxy-client": "^3.7.2"
   },
   "peerDependencies": {
     "next": ">=12",

--- a/lib/package.json
+++ b/lib/package.json
@@ -53,7 +53,7 @@
     "commander": "12.1.0",
     "murmurhash3js": "3.0.1",
     "semver": "7.6.3",
-    "unleash-client": "^6.4.0",
+    "unleash-client": "^6.4.1",
     "unleash-proxy-client": "^3.7.1"
   },
   "peerDependencies": {

--- a/lib/src/flagsClient.test.ts
+++ b/lib/src/flagsClient.test.ts
@@ -125,6 +125,9 @@ describe("flagsClient", () => {
         Authorization: 'a-very-nice-very-secure-custom-key',
         Accept: 'application/json',
         'Content-Type': 'application/json',
+        'x-unleash-appname': 'custom-app-name',
+        'x-unleash-connection-id': expect.stringMatching(/[a-f0-9-]{36}/),
+        'x-unleash-sdk': 'unleash-js@3.7.1',
       },
       body: expect.stringContaining('custom-app-name'),
     }));

--- a/lib/src/flagsClient.test.ts
+++ b/lib/src/flagsClient.test.ts
@@ -127,7 +127,7 @@ describe("flagsClient", () => {
         'Content-Type': 'application/json',
         'x-unleash-appname': 'custom-app-name',
         'x-unleash-connection-id': expect.stringMatching(/[a-f0-9-]{36}/),
-        'x-unleash-sdk': 'unleash-js@3.7.1',
+        'x-unleash-sdk': expect.stringMatching(/^unleash-js@\d\.\d\.\d/),
       },
       body: expect.stringContaining('custom-app-name'),
     }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4353,10 +4353,10 @@ unleash-proxy-client@3.6.1:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"
 
-unleash-proxy-client@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.1.tgz#c51483aebaad664e6d6ea70828f5f10bece61a40"
-  integrity sha512-ri3cauGfQBjvRvwwJIQfnHlpOfFvQz0iy5hVd82Tr4t0LkqpqFr248tuO8jkI39JXelUcX7TCGNHneeMMPZM1A==
+unleash-proxy-client@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.2.tgz#c6166bbaf293f8dea12cf65d061d72234c5b76a8"
+  integrity sha512-1SvHsl3kQh1DT9EKMQsN9alOvXZEz9hpxa3mG6QWtTmXJqa6VZi25dQ2U8Y2KAULKg6ARLMUQkod74Fe/pKp0g==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,6 +1003,20 @@
   resolved "https://registry.yarnpkg.com/@unleash/client-specification/-/client-specification-5.1.7.tgz#8f8363803cca96afca4e65938d97951ffa8facc4"
   integrity sha512-PIaVKrFuXS/HMaWFOmLVAKssNlPKVvQ1+EgUMZ+SL+4d1U2bMevR8QJB0Efk2F6FhjSvJTN1vPlpuacfc/F25A==
 
+"@unleash/nextjs@*":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@unleash/nextjs/-/nextjs-1.5.0.tgz#d6df6347c090a4f385327df5320dbb26de94ee63"
+  integrity sha512-c0X+3/xVoPszOJknJwByw4L5tKJqxGPIufeI5dtL2m9KX/KoBRHuYc1YtxG1kE8Uf6Bv+faTnKWHB02w09pEHw==
+  dependencies:
+    "@commander-js/extra-typings" "12.1.0"
+    "@next/env" "14.2.13"
+    "@unleash/proxy-client-react" "4.3.1"
+    commander "12.1.0"
+    murmurhash3js "3.0.1"
+    semver "7.6.3"
+    unleash-client "6.1.1"
+    unleash-proxy-client "3.6.1"
+
 "@unleash/proxy-client-react@4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@unleash/proxy-client-react/-/proxy-client-react-4.3.1.tgz#49d43224aa493fc8e589f043c8ff983c526099f8"
@@ -4311,6 +4325,14 @@ unleash-proxy-client@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.6.1.tgz#ec709bd03010d190977f99a0900117f9e9ab6ea4"
   integrity sha512-gbvkob/cBewLHMh9aAwWLDLN8D1efJ5FdUMva7wGBVykJMIqyYIlUsJpVNXnpq+feNBn6Qc1D1huXD2bk9bEmA==
+  dependencies:
+    tiny-emitter "^2.1.0"
+    uuid "^9.0.1"
+
+unleash-proxy-client@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.1.tgz#c51483aebaad664e6d6ea70828f5f10bece61a40"
+  integrity sha512-ri3cauGfQBjvRvwwJIQfnHlpOfFvQz0iy5hVd82Tr4t0LkqpqFr248tuO8jkI39JXelUcX7TCGNHneeMMPZM1A==
   dependencies:
     tiny-emitter "^2.1.0"
     uuid "^9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,6 +2948,11 @@ language-tags@^1.0.9:
   dependencies:
     language-subtag-registry "^0.3.20"
 
+launchdarkly-eventsource@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/launchdarkly-eventsource/-/launchdarkly-eventsource-2.0.3.tgz#8a7b8da5538153f438f7d452b1c87643d900f984"
+  integrity sha512-VhFjppK7jXlcEKaS7bxdoibB5j01NKyeDR7a8XfssdDGNWCTsbF0/5IExSmPi44eDncPhkoPNxlSZhEZvrbD5w==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -3537,6 +3542,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -4319,6 +4329,20 @@ unleash-client@6.1.1:
     ip-address "^9.0.5"
     make-fetch-happen "^13.0.1"
     murmurhash3js "^3.0.1"
+    semver "^7.6.2"
+
+unleash-client@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-6.4.0.tgz#bd148e3290e46f24365fe379353b526a99b19a84"
+  integrity sha512-jxnqYNFLDRVaBIwocsDHKBmEaiY1HG+yjQCrILy0g8LWIrYLwRV9P+pfqRFdNiD3gaGXqfqjfxXR0IwjrofKLg==
+  dependencies:
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.5"
+    ip-address "^9.0.5"
+    launchdarkly-eventsource "2.0.3"
+    make-fetch-happen "^13.0.1"
+    murmurhash3js "^3.0.1"
+    proxy-from-env "^1.1.0"
     semver "^7.6.2"
 
 unleash-proxy-client@3.6.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,10 +4331,10 @@ unleash-client@6.1.1:
     murmurhash3js "^3.0.1"
     semver "^7.6.2"
 
-unleash-client@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-6.4.0.tgz#bd148e3290e46f24365fe379353b526a99b19a84"
-  integrity sha512-jxnqYNFLDRVaBIwocsDHKBmEaiY1HG+yjQCrILy0g8LWIrYLwRV9P+pfqRFdNiD3gaGXqfqjfxXR0IwjrofKLg==
+unleash-client@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-6.4.1.tgz#ae9a570e23488a250c74fb1576611bca5130eeb1"
+  integrity sha512-Tu2fNqu2Gy3u0KnJh0kPmyCAnEi1hr6319ct3rSjE1e4kEIlML6ZDwqUNZk2t6/yzijrGfgFfVJRxTivYEBVfQ==
   dependencies:
     http-proxy-agent "^7.0.2"
     https-proxy-agent "^7.0.5"


### PR DESCRIPTION
Updates the dependency on the underlying Unleash client to 3.7.2. This
version of the client adds new x-unleash headers which lets Unleash
count unique connections and see SDK version information.

Also updates the node client to 6.4.1 which includes the new headers for the server side (even though next uses it's own fetching).