### PR TITLE
docs: fix pages router caching examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,18 +385,14 @@ export default async function Page() {
 #### Page router
 ```tsx
 import { evaluateFlags, flagsClient, getDefinitions } from "@unleash/nextjs";
-import {GetServerSideProps, NextPage} from "next";
+import type { GetServerSideProps, NextPage } from "next";
 
 type Data = {
   isEnabled: boolean;
 };
 
 export const getServerSideProps: GetServerSideProps<Data> = async () => {
-  const definitions = await getDefinitions({
-    fetchOptions: {
-      next: { revalidate: 15 }, // Cache layer like Unleash Proxy!
-    },
-  });
+  const definitions = await getDefinitions();
   const context = {};
   const { toggles } = evaluateFlags(definitions, context);
   const flags = flagsClient(toggles);

--- a/example/src/pages/ssr.tsx
+++ b/example/src/pages/ssr.tsx
@@ -35,6 +35,10 @@ export const getServerSideProps: GetServerSideProps<Data> = async (ctx) => {
     "set-cookie",
     `${UNLEASH_COOKIE_NAME}=${sessionId}; path=/;`
   );
+  ctx.res.setHeader( 
+    'Cache-Control', // In Pages Router you can cache entrie response, but not Unlaesh request only
+    'public, s-maxage=10, stale-while-revalidate=59'
+  )
 
   const definitions = await getDefinitions();
   const { toggles } = evaluateFlags(definitions, {


### PR DESCRIPTION
`fetchOptions` are not available in pages router